### PR TITLE
fix adc includes

### DIFF
--- a/PY32F0xx_HAL_Driver/Inc/py32f0xx_hal_adc.h
+++ b/PY32F0xx_HAL_Driver/Inc/py32f0xx_hal_adc.h
@@ -30,6 +30,9 @@ extern "C" {
 
 /* Includes ------------------------------------------------------------------*/
 #include "py32f0xx_hal_def.h"
+#if (defined(DMA) || defined(DMA1))
+  #include "py32f0xx_hal_dma.h"
+#endif
 
 /** @addtogroup PY32F0xx_HAL_Driver
   * @{


### PR DESCRIPTION
I tried to use this HAL library with a PY32F003F18 and I was getting errors from `py32f0xx_hal_adc.h` when compiling because the `DMA_HandleTypeDef` type was not being defined.

I didn't read through the library closely but was able to resolve the issue by having `py32f0xx_hal_adc.h` include the necessary DMA header when there is DMA on the chip.